### PR TITLE
Make cache refresh on plugin load configurable via a setting

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,26 @@
+[{
+	"caption": "Preferences",
+	"id": "preferences",
+	"mnemonic": "n",
+	"children": [{
+		"caption": "Package Settings",
+		"id": "package-settings",
+		"mnemonic": "P",
+		"children": [{
+			"caption": "Salesforce Reference",
+			"children": [{
+				"caption": "Settings – Default",
+				"command": "open_file",
+				"args": {
+					"file": "${packages}/SublimeSalesforceReference/SublimeSalesforceReference.sublime-settings"
+				}
+			}, {
+				"caption": "Settings – User",
+				"command": "open_file",
+				"args": {
+					"file": "${packages}/User/SublimeSalesforceReference.sublime-settings"
+				}
+			}]
+		}]
+	}]
+}]

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -19,9 +19,11 @@ class SalesforceReferenceCache():
 reference_cache = SalesforceReferenceCache()
 
 def plugin_loaded():
-    thread = RetrieveIndexThread(sublime.active_window(),False)
-    thread.start()
-    ThreadProgress(thread, 'Retrieving Salesforce Reference Index...', '')
+    settings = sublime.load_settings("SublimeSalesforceReference.sublime-settings")
+    if settings != None and settings.get("refreshCacheOnLoad") == True:
+        thread = RetrieveIndexThread(sublime.active_window(),False)
+        thread.start()
+        ThreadProgress(thread, 'Retrieving Salesforce Reference Index...', '')
 
 
 class SalesforceReferenceCommand(sublime_plugin.WindowCommand):

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -1,0 +1,3 @@
+{
+	"refreshCacheOnLoad": true
+}


### PR DESCRIPTION
- Default setting included with cache refresh set to true
- Adds menu items for default and user settings

_Note: might pay to double-check that menu links to setting files refer to the correct directory name_
