### PR TITLE
Visualforce documentation. Settings enhancement

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,18 @@
 [
   {
-    "caption": "Salesforce Reference",
-    "command": "salesforce_reference"
+    "caption": "Salesforce Apex Reference",
+    "command": "salesforce_apex_reference"
+  },
+  {
+    "caption": "Salesforce Visualforce Reference",
+    "command": "salesforce_visualforce_reference"
+  },
+  {
+    "caption": "Salesforce Service Console Reference",
+    "command": "salesforce_service_console_reference"
+  },
+  {
+    "caption": "Salesforce All Reference",
+    "command": "salesforce_all_reference"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
 ## Key bindings
 
 Availables commands for key bindings are:
-    1. salesforce_apex_reference
-    2. salesforce_visualforce_reference
-    3. salesforce_service_console_reference
-    4. salesforce_all_reference
+    * salesforce_apex_reference
+    * salesforce_visualforce_reference
+    * salesforce_service_console_reference
+    * salesforce_all_reference
 
 To set a key binding to one of these go to Preferences > Key Bindings - User
 and insert something like this:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     // visualforceDoc:
     // Setting this to false means the plugin wont download Visualforce
     // reference entries
-    "visualforceDoc": true
+    "visualforceDoc": true,
+    
+    // serviceConsoleDoc:
+    // Setting this to false means the plugin wont download Service Console
+    // Javascript toolkit reference entries
+    serviceConsoleDoc: true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,31 +21,35 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
 
 ``` json
 {
-    //  refreshCacheOnLoad:
-    //
-    //  Setting this to false means the plugin will need to do a callout
-    //      to retrieve the Salesforce Reference Index from Salesforce
-    //      when the *Salesforce Reference* command is first run.
-    //
-    //      When set to true (RECOMMENDED, and the default setting), the
-    //      plugin will cache the Reference Index when Sublime Text starts
-    //      or the plugin is reloaded
+    /*  refreshCacheOnLoad:
+    *
+    *  Setting this to false means the plugin will need to do a callout
+    *      to retrieve the Salesforce Reference Index from Salesforce
+    *     when the *Salesforce Reference* command is first run.
+    *
+    *      When set to true (RECOMMENDED, and the default setting), the
+    *      plugin will cache the Reference Index when Sublime Text starts
+    *      or the plugin is reloaded
+    */
     "refreshCacheOnLoad": true,
     
-    // apexDoc:
-    // Setting this to false means the plugin wont download Apex
-    // reference entries
+    /* apexDoc:
+    * Setting this to false means the plugin wont download Apex
+    * reference entries
+    */
     "apexDoc": true,
     
-    // visualforceDoc:
-    // Setting this to false means the plugin wont download Visualforce
-    // reference entries
+    /* visualforceDoc:
+    * Setting this to false means the plugin wont download Visualforce
+    * reference entries
+    */
     "visualforceDoc": true,
     
-    // serviceConsoleDoc:
-    // Setting this to false means the plugin wont download Service Console
-    // Javascript toolkit reference entries
-    serviceConsoleDoc: true
+    /* serviceConsoleDoc:
+    * Setting this to false means the plugin wont download Service Console
+    * Javascript toolkit reference entries
+    */
+    "serviceConsoleDoc": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
 ## Key bindings
 
 Availables commands for key bindings are:
+
     * salesforce_apex_reference
     * salesforce_visualforce_reference
     * salesforce_service_console_reference

--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     //      When set to true (RECOMMENDED, and the default setting), the
     //      plugin will cache the Reference Index when Sublime Text starts
     //      or the plugin is reloaded
-    "refreshCacheOnLoad": true 
+    "refreshCacheOnLoad": true,
+    
+    // apexDoc:
+    // Setting this to false means the plugin wont download Apex
+    // reference entries
+    "apexDoc": true,
+    
+    // visualforceDoc:
+    // Setting this to false means the plugin wont download Visualforce
+    // reference entries
+    "visualforceDoc": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Availables commands for key bindings are:
 
 To set a key binding to one of these go to Preferences > Key Bindings - User
 and insert something like this:
-    ```json
-    {
-        "keys": ["alt+s"],
-        "command": "salesforce_all_reference"
-    }
-    ```
+``` json
+{
+    "keys": ["alt+s"],
+    "command": "salesforce_all_reference"
+}
+```
 
 ## Contributing, Bugs, Suggestions, Questions
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     serviceConsoleDoc: true
 }
 ```
+Availables commands for key bindings are:
+    - salesforce_apex_reference
+    - salesforce_visualforce_reference
+    - salesforce_service_console_reference
+    - salesforce_all_reference
+
+To set a key binding to one of these go to Preferences > Key Bindings - User
+and insert something like this:
+    {
+        "keys": ["alt+s"],
+        "command": "salesforce_all_reference"
+    }
 
 ## Contributing, Bugs, Suggestions, Questions
 

--- a/README.md
+++ b/README.md
@@ -48,18 +48,23 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     serviceConsoleDoc: true
 }
 ```
+
+## Key bindings
+
 Availables commands for key bindings are:
-    - salesforce_apex_reference
-    - salesforce_visualforce_reference
-    - salesforce_service_console_reference
-    - salesforce_all_reference
+    1. salesforce_apex_reference
+    2. salesforce_visualforce_reference
+    3. salesforce_service_console_reference
+    4. salesforce_all_reference
 
 To set a key binding to one of these go to Preferences > Key Bindings - User
 and insert something like this:
+    ```json
     {
         "keys": ["alt+s"],
         "command": "salesforce_all_reference"
     }
+    ```
 
 ## Contributing, Bugs, Suggestions, Questions
 

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -236,7 +236,7 @@ class RetrieveIndexThread(threading.Thread):
         sf_html = urllib.request.urlopen(urllib.request.Request(SALESFORCE_VISUALFORCE_DOC_URL_BASE,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
         page_soup = BeautifulSoup(sf_html, "html.parser")
         reference_soup = page_soup.find_all(text="Standard Component Reference",class_="toc-text")[0].parent.parent.parent
-        span_list = reference_soup.find_all("span", class_="toc-text", text=re.compile("^(?!Standard Component Reference)"))
+        span_list = reference_soup.find_all("span", class_="toc-text")
         for span in span_list:
             link = span.parent
             reference_cache.append(

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -30,9 +30,15 @@ sys.path.append(os.path.join(os.path.dirname(__file__), os.path.normpath("lib"))
 from bs4 import BeautifulSoup
 import html.parser
 
+#These are Salesforce official documentation links
 SALESFORCE_APEX_DOC_URL_BASE = "http://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/"
 SALESFORCE_VISUALFORCE_DOC_URL_BASE = "http://developer.salesforce.com/docs/atlas.en-us.pages.meta/pages/"
 SALESFORCE_SERVICECONSOLE_DOC_URL_BASE = "http://developer.salesforce.com/docs/atlas.en-us.api_console.meta/api_console/"
+
+#These are available documentation type
+VISUALFORCE = "visualforce"
+APEX = "apex"
+SERVICECONSOLE = "serviceconsole"
 
 class SalesforceReferenceCache(collections.MutableSequence):
     """
@@ -43,9 +49,32 @@ class SalesforceReferenceCache(collections.MutableSequence):
         self.entries = list(data)
         self.__sort_by_title()
         self.__determine_titles()
+    
+    # Properties to display entries title in quick panel
     @property
     def titles(self):
         return self.__titles
+    @property
+    def apexTitles(self):
+        return list(map(lambda entry: entry.title, self.__filter_entries(APEX)))
+    @property
+    def visualforceTitles(self):
+        return list(map(lambda entry: entry.title, self.__filter_entries(VISUALFORCE)))
+    @property
+    def serviceconsoleTitles(self):
+        return list(map(lambda entry: entry.title, self.__filter_entries(SERVICECONSOLE)))
+    
+    # Properties to return a list of filtered entries
+    @property
+    def apexEntries(self):
+        return self.__filter_entries(APEX)
+    @property
+    def visualforceEntries(self):
+        return self.__filter_entries(VISUALFORCE)
+    @property
+    def serviceconsoleEntries(self):
+        return self.__filter_entries(SERVICECONSOLE)
+    
     def __getitem__(self, key):
         return self.entries[key]
     def __setitem__(self, key, value):
@@ -65,6 +94,12 @@ class SalesforceReferenceCache(collections.MutableSequence):
         self.__determine_titles()
     def __determine_titles(self):
         self.__titles = list(map(lambda entry: entry.title,self.entries))
+    #Return a list of entries filtered by docType and ordered by title
+    def __filter_entries(self, docType):
+        entries = [entry for entry in self.entries if entry.docType == docType]
+        entries.sort(key=lambda cacheEntry: cacheEntry.title)
+        return entries
+    
     """str and repr implemented for debugging"""
     def __str__(self):
         return str(self.entries)
@@ -83,62 +118,97 @@ class SalesforceReferenceCacheEntry(object):
     def __repr__(self):
         return str({"title":self.title,"url":self.url})
 
+#Store all reference entries
 reference_cache = SalesforceReferenceCache()
 
 def plugin_loaded():
     # Get settings
-    global settings 
+    global settings
     settings = sublime.load_settings("SublimeSalesforceReference.sublime-settings")    
-    if settings != None and settings.get("refreshCacheOnLoad") == True:        
-        thread = RetrieveIndexThread(sublime.active_window(),False)
+    if settings != None and settings.get("refreshCacheOnLoad") == True:
+        thread = RetrieveIndexThread(sublime.active_window(), "all", False)        
         thread.start()
         ThreadProgress(thread, "Retrieving Salesforce Reference Index...", "")
 
 
-class SalesforceReferenceCommand(sublime_plugin.WindowCommand):
+class SalesforceApexReferenceCommand(sublime_plugin.WindowCommand):
     def run(self):
-        thread = RetrieveIndexThread(self.window)
+        thread = RetrieveIndexThread(self.window, APEX)        
+        thread.start()
+        ThreadProgress(thread, "Retrieving Salesforce Apex Reference Index...", "")
+
+class SalesforceVisualforceReferenceCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        thread = RetrieveIndexThread(self.window, VISUALFORCE)        
+        thread.start()
+        ThreadProgress(thread, "Retrieving Salesforce Visualforce Reference Index...", "")
+
+class SalesforceServiceConsoleReferenceCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        thread = RetrieveIndexThread(self.window, SERVICECONSOLE)        
+        thread.start()
+        ThreadProgress(thread, "Retrieving Salesforce Service Console Reference Index...", "")
+
+class SalesforceAllReferenceCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        thread = RetrieveIndexThread(self.window, "all")
         thread.start()
         ThreadProgress(thread, "Retrieving Salesforce Reference Index...", "")
-
 
 class RetrieveIndexThread(threading.Thread):
     """
     A thread to run retrieval of the Saleforce Documentation index, or access the reference_cache
     """
 
-    def __init__(self, window, open_when_done=True):
+    def __init__(self, window, docType, open_when_done=True):
         """
         :param window:
             An instance of :class:`sublime.Window` that represents the Sublime
             Text window to show the available package list in.
+        :param docType:
+            Specify what kind of documentation to retrieve. Accepted values are:
+                apex, retrive only apex reference entries
+                visualforce, retrieve only visualforce entries
+                serviceconsole, retrieve only service console entries
+                all, retrieve references specified in Settings file
         :param open_when_done:
             Whether this thread is being run solely for caching, or should open
             the documentation list for user selection when done. Defaults to
             true - should open the documentaton list when done
         """
         self.window = window
+        self.docType = docType
         self.open_when_done = open_when_done
         global reference_cache
         threading.Thread.__init__(self)
 
     def run(self):        
-        if not (reference_cache.entries):
-            #Check if has to get APEX doc entries            
-            if settings.get("apexDoc") == True:
+        #Check if has to get APEX doc entries            
+        if self.docType == APEX or (self.docType == "all" and settings.get("apexDoc") == True):
+            if not reference_cache.apexEntries:
                 self.__get_apex_doc()
-                            
-            #Check if has to get Visualforce doc entries
-            if settings.get("visualforceDoc") == True:
+                        
+        #Check if has to get Visualforce doc entries
+        if self.docType == VISUALFORCE or (self.docType == "all" and settings.get("visualforceDoc") == True):
+            if not reference_cache.visualforceEntries:
                 self.__get_visualforce_doc()
 
-            #Check if has to get Service Console doc entries
-            if settings.get("serviceConsoleDoc") == True:
+        #Check if has to get Service Console doc entries
+        if self.docType == SERVICECONSOLE or (self.docType == "all" and settings.get("serviceConsoleDoc") == True):
+            if not reference_cache.serviceconsoleEntries:
                 self.__get_serviceconsole_doc();
-            
+        
         if(self.open_when_done):
-            self.window.show_quick_panel(reference_cache.titles, self.open_documentation)
-    
+            #Check what kind of docs has to show
+            if (self.docType == "all"):
+                self.window.show_quick_panel(reference_cache.titles, self.open_documentation)
+            elif (self.docType == APEX):
+                self.window.show_quick_panel(reference_cache.apexTitles, self.open_documentation)
+            elif (self.docType == VISUALFORCE):
+                self.window.show_quick_panel(reference_cache.visualforceTitles, self.open_documentation)
+            elif (self.docType == SERVICECONSOLE):
+                self.window.show_quick_panel(reference_cache.serviceconsoleTitles, self.open_documentation)
+            
     #Download SERVICE CONSOLE integration toolkit doc entries
     def __get_serviceconsole_doc(self):
         sf_html = urllib.request.urlopen(urllib.request.Request(SALESFORCE_SERVICECONSOLE_DOC_URL_BASE,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
@@ -152,7 +222,7 @@ class RetrieveIndexThread(threading.Thread):
                     SalesforceReferenceCacheEntry(
                         span.string,
                         link["href"],
-                        "ServiceConsole"
+                        SERVICECONSOLE
                     )
                 )
 
@@ -168,7 +238,7 @@ class RetrieveIndexThread(threading.Thread):
                     SalesforceReferenceCacheEntry(
                         span.string,
                         link["href"],
-                        "Visualforce"
+                        VISUALFORCE
                     )
                 )
     
@@ -188,16 +258,29 @@ class RetrieveIndexThread(threading.Thread):
                     SalesforceReferenceCacheEntry(
                         header_data_tag.find(class_="toc-text").string,
                         header_data_tag["href"],
-                        "Apex"
+                        APEX
                     )
                 )
 
     def open_documentation(self, reference_index):
+        url = ""
         if(reference_index != -1):
-            # Check entry's type (Apex or Visualforce)
-            if reference_cache[reference_index].docType == "Apex":
-                webbrowser.open_new_tab(SALESFORCE_APEX_DOC_URL_BASE + reference_cache[reference_index].url)
-            elif reference_cache[reference_index].docType == "Visualforce":
-                webbrowser.open_new_tab(SALESFORCE_VISUALFORCE_DOC_URL_BASE + reference_cache[reference_index].url)
-            elif reference_cache[reference_index].docType == "ServiceConsole"
-                webbrowser.open_new_tab(SALESFORCE_SERVICECONSOLE_DOC_URL_BASE + reference_cache[reference_index].url)
+            if self.docType == APEX:
+                entry = reference_cache.apexEntries[reference_index]
+            elif self.docType == VISUALFORCE:
+                entry = reference_cache.visualforceEntries[reference_index]
+            elif self.docType == SERVICECONSOLE:
+                entry = reference_cache.serviceconsoleEntries[reference_index]
+            elif self.docType == "all":
+                entry = reference_cache[reference_index]
+            
+            if entry:
+                if entry.docType == APEX:
+                    url = SALESFORCE_APEX_DOC_URL_BASE + entry.url
+                elif entry.docType == VISUALFORCE:
+                    url = SALESFORCE_VISUALFORCE_DOC_URL_BASE + entry.url
+                elif entry.docType == SERVICECONSOLE:
+                    url = SALESFORCE_SERVICECONSOLE_DOC_URL_BASE + entry.url
+            
+            if url:
+                webbrowser.open_new_tab(url)

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ElementTree
 import webbrowser
 import threading
 import collections
+import re
 from .ThreadProgress import ThreadProgress
 
 # Import BeautifulSoup (scraping library) and html.parser
@@ -140,8 +141,20 @@ class RetrieveIndexThread(threading.Thread):
     
     #Download SERVICE CONSOLE integration toolkit doc entries
     def __get_serviceconsole_doc(self):
-        #Work in progress
-        pass
+        sf_html = urllib.request.urlopen(urllib.request.Request(SALESFORCE_SERVICECONSOLE_DOC_URL_BASE,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
+        page_soup = BeautifulSoup(sf_html, "html.parser")
+        reference_soup = page_soup.find_all("span", string=re.compile("Methods for \w"), class_="toc-text")
+        for reference in reference_soup:
+            span_list = reference.parent.parent.parent.find_all("span", class_="toc-text", string=re.compile("^(?!Methods for)"))
+            for span in span_list:
+                link = span.parent
+                reference_cache.append(
+                    SalesforceReferenceCacheEntry(
+                        span.string,
+                        link["href"],
+                        "ServiceConsole"
+                    )
+                )
 
     #Download VISUALFORCE doc entries
     def __get_visualforce_doc(self):        
@@ -186,3 +199,5 @@ class RetrieveIndexThread(threading.Thread):
                 webbrowser.open_new_tab(SALESFORCE_APEX_DOC_URL_BASE + reference_cache[reference_index].url)
             elif reference_cache[reference_index].docType == "Visualforce":
                 webbrowser.open_new_tab(SALESFORCE_VISUALFORCE_DOC_URL_BASE + reference_cache[reference_index].url)
+            elif reference_cache[reference_index].docType == "ServiceConsole"
+                webbrowser.open_new_tab(SALESFORCE_SERVICECONSOLE_DOC_URL_BASE + reference_cache[reference_index].url)

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -18,5 +18,10 @@
     // visualforceDoc:
     // Setting this to false means the plugin wont download Visualforce
     // reference entries
-    "visualforceDoc": false 
+    "visualforceDoc": false,
+    
+    // serviceConsoleDoc:
+    // Setting this to false means the plugin wont download Service Console
+    // Javascript toolkit reference entries
+    serviceConsoleDoc: false
 }

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -23,5 +23,5 @@
     // serviceConsoleDoc:
     // Setting this to false means the plugin wont download Service Console
     // Javascript toolkit reference entries
-    serviceConsoleDoc: false
+    "serviceConsoleDoc": false
 }

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -8,5 +8,15 @@
     //      When set to true (RECOMMENDED, and the default setting), the
     //      plugin will cache the Reference Index when Sublime Text starts
     //      or the plugin is reloaded
-    "refreshCacheOnLoad": true 
+    "refreshCacheOnLoad": true,
+    
+    // apexDoc:
+    // Setting this to false means the plugin wont download Apex
+    // reference entries
+    "apexDoc": true,
+    
+    // visualforceDoc:
+    // Setting this to false means the plugin wont download Visualforce
+    // reference entries
+    "visualforceDoc": false 
 }


### PR DESCRIPTION
Hi guys,
let me say thanks, before i start, this plugin is really awsome and save me a lot of time!

I added a couple of functionality here...
First of all, i added the method to download also Visualforce standard component references. I found it very useful when i have to deal with both Apex and Visualforce.

A little bit of code refactoring. I added two method, one to retrieve Apex documentation and the other for Visualforce one.

Added two settings in plugin's setting file to let users configure what kind of documentation to download.

What you think?

