### PR TITLE
Extra doc types and more threading + 2.0.0 prep

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,18 +1,18 @@
 [
   {
-    "caption": "Salesforce Apex Reference",
-    "command": "salesforce_apex_reference"
+    "caption": "Salesforce Reference - Apex",
+    "command": "salesforce_reference_apex"
   },
   {
-    "caption": "Salesforce Visualforce Reference",
-    "command": "salesforce_visualforce_reference"
+    "caption": "Salesforce Reference - Visualforce",
+    "command": "salesforce_reference_visualforce"
   },
   {
-    "caption": "Salesforce Service Console Reference",
-    "command": "salesforce_service_console_reference"
+    "caption": "Salesforce Reference - Service Console",
+    "command": "salesforce_reference_service_console"
   },
   {
-    "caption": "Salesforce All Reference",
-    "command": "salesforce_all_reference"
+    "caption": "Salesforce Reference - All Documentation Types",
+    "command": "salesforce_reference_all_documentation_types"
   }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,18 @@
 [
   {
-    "caption": "Salesforce Reference",
-    "command": "salesforce_reference"
+    "caption": "Salesforce Apex Reference",
+    "command": "salesforce_apex_reference"
+  },
+  {
+    "caption": "Salesforce Visualforce Reference",
+    "command": "salesforce_visualforce_reference"
+  },
+  {
+    "caption": "Salesforce Service Console Reference",
+    "command": "salesforce_service_console_reference"
+  },
+  {
+    "caption": "Salesforce All Reference",
+    "command": "salesforce_all_reference"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A plugin for Sublime Text that gives you quick access to Salesforce Documentatio
 
 SublimeSalesforceReference adds a new command to your palette: *'Salesforce Reference'*. Simply select this command, and the plugin will retrieve an index of reference pages from Salesforce and show them to you in a quick panel. Search for what you're after, press enter, and the documentation page will open in your web browser!
 
-![](http://oblongmana.com/images/doc/sublime-salesforce-reference/usage.png)
+![](http://jameshill.io/images/doc/sublime-salesforce-reference/usage.png)
 
 By default, the plugin will make a callout to cache the Salesforce Reference Index when Sublime Text opens, so that when you run the *Salesforce Reference* command, the list of reference pages will open instantly. You can disable the cache-on-load behaviour (see the Settings section for how to do so), in which case the cache will be filled the first time you run the command.
 
@@ -89,7 +89,7 @@ If you don't follow those instructions precisely, it's probably no big deal, we'
 ## License
 
 ### Sublime Salesforce Reference
-Copyright (c) 2014-2015 James Hill <oblongmana@gmail.com>
+Copyright (c) 2014-2015 James Hill <me@jameshill.io>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
 ## Key bindings
 
 Availables commands for key bindings are:
-    1. salesforce_apex_reference
-    2. salesforce_visualforce_reference
-    3. salesforce_service_console_reference
-    4. salesforce_all_reference
+    * salesforce_apex_reference
+    * salesforce_visualforce_reference
+    * salesforce_service_console_reference
+    * salesforce_all_reference
 
 To set a key binding to one of these go to Preferences > Key Bindings - User
 and insert something like this:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     // visualforceDoc:
     // Setting this to false means the plugin wont download Visualforce
     // reference entries
-    "visualforceDoc": true
+    "visualforceDoc": true,
+    
+    // serviceConsoleDoc:
+    // Setting this to false means the plugin wont download Service Console
+    // Javascript toolkit reference entries
+    serviceConsoleDoc: true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,31 +21,35 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
 
 ``` json
 {
-    //  refreshCacheOnLoad:
-    //
-    //  Setting this to false means the plugin will need to do a callout
-    //      to retrieve the Salesforce Reference Index from Salesforce
-    //      when the *Salesforce Reference* command is first run.
-    //
-    //      When set to true (RECOMMENDED, and the default setting), the
-    //      plugin will cache the Reference Index when Sublime Text starts
-    //      or the plugin is reloaded
+    /*  refreshCacheOnLoad:
+    *
+    *  Setting this to false means the plugin will need to do a callout
+    *      to retrieve the Salesforce Reference Index from Salesforce
+    *     when the *Salesforce Reference* command is first run.
+    *
+    *      When set to true (RECOMMENDED, and the default setting), the
+    *      plugin will cache the Reference Index when Sublime Text starts
+    *      or the plugin is reloaded
+    */
     "refreshCacheOnLoad": true,
     
-    // apexDoc:
-    // Setting this to false means the plugin wont download Apex
-    // reference entries
+    /* apexDoc:
+    * Setting this to false means the plugin wont download Apex
+    * reference entries
+    */
     "apexDoc": true,
     
-    // visualforceDoc:
-    // Setting this to false means the plugin wont download Visualforce
-    // reference entries
+    /* visualforceDoc:
+    * Setting this to false means the plugin wont download Visualforce
+    * reference entries
+    */
     "visualforceDoc": true,
     
-    // serviceConsoleDoc:
-    // Setting this to false means the plugin wont download Service Console
-    // Javascript toolkit reference entries
-    serviceConsoleDoc: true
+    /* serviceConsoleDoc:
+    * Setting this to false means the plugin wont download Service Console
+    * Javascript toolkit reference entries
+    */
+    "serviceConsoleDoc": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
 ## Key bindings
 
 Availables commands for key bindings are:
+
     * salesforce_apex_reference
     * salesforce_visualforce_reference
     * salesforce_service_console_reference

--- a/README.md
+++ b/README.md
@@ -9,17 +9,24 @@ A plugin for Sublime Text that gives you quick access to Salesforce Documentatio
 
 ## Usage 
 
-SublimeSalesforceReference adds a new command to your palette: *'Salesforce Reference'*. Simply select this command, and the plugin will retrieve an index of reference pages from Salesforce and show them to you in a quick panel. Search for what you're after, press enter, and the documentation page will open in your web browser!
+SublimeSalesforceReference adds multiple new commands to your palette:
+  - `Salesforce Reference - Apex`
+  - `Salesforce Reference - Visualforce`
+  - `Salesforce Reference - Service Console`
+  - `Salesforce Reference - All Documentation Types` 
+Simply select one of these command, and the plugin will retrieve an index of reference pages from Salesforce and show them to you in a quick panel. Search for what you're after, press enter, and the documentation page will open in your web browser!
+
+Each of the commands is reasonably self-explanatory - the `Salesforce Reference - Apex` command shows the a list of Apex documentation pages, and so on; while the `Salesforce Reference - All Documentation Types` shows in a single list the documentation for all doc types this plugin supports.
 
 ![](http://jameshill.io/images/doc/sublime-salesforce-reference/usage.png)
 
-By default, the plugin will make a callout to cache the Salesforce Reference Index when Sublime Text opens, so that when you run the *Salesforce Reference* command, the list of reference pages will open instantly. You can disable the cache-on-load behaviour (see the Settings section for how to do so), in which case the cache will be filled the first time you run the command.
+By default, when Sublime Text starts up, the plugin will make a callout to cache the Salesforce Reference Index for the `Apex` and `Visualforce` documentation, so that when you run a `Salesforce Reference` command, the list of reference pages will open instantly. You can disable the cache-on-load behaviour (see the Settings section for how to do so), in which case the cache will be filled the first time you run the command. You can also specify which types of documentation should be cached (for example, by default the `Service Console` documentation is not cached on load - but you can make it so!)
 
 ## Settings
 
 To edit your settings, go to Preferences > Package Settings > Salesforce Reference > Settings - User
 
-``` json
+``` javascript
 {
     /*  refreshCacheOnLoad:
     *
@@ -33,41 +40,59 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     */
     "refreshCacheOnLoad": true,
     
-    /* apexDoc:
-    * Setting this to false means the plugin wont download Apex
-    * reference entries
-    */
-    "apexDoc": true,
-    
-    /* visualforceDoc:
-    * Setting this to false means the plugin wont download Visualforce
-    * reference entries
-    */
-    "visualforceDoc": true,
-    
-    /* serviceConsoleDoc:
-    * Setting this to false means the plugin wont download Service Console
-    * Javascript toolkit reference entries
-    */
-    "serviceConsoleDoc": true
+    /**
+     *  docTypes:
+     *
+     *  Each docType has one option:
+     *   - refreshCacheOnLoad:
+     *       if the top-level refreshCacheOnLoad setting is true, and this
+     *       docType's refreshCacheOnLoad setting is true - this documentation
+     *       type will be cache when sublime starts up. Otherwise, this
+     *       documentation type will only be retrieved and cached when it's
+     *       corresponding command is run
+     *   - excludeFromAllDocumentationCommand:
+     *       if this is set to true, the command "Salesforce Reference - All
+     *       Documentation Types" will not include this documentation type.
+     *       If set to false for a documentation type, uou'll only be able to
+     *       view that documentation type with from the command specific to it,
+     *       it won't be included in the command "Salesforce Reference - All
+     *       Documentation Types"
+     *
+     *  Note to developers: the keys in `docTypes` should be an exact lowercase
+     *   match of one of the keys in salesforce_reference.retrieve.DocTypeEnum
+     */
+    "docTypes": {
+      "apex": {
+        "refreshCacheOnLoad": true,
+        "excludeFromAllDocumentationCommand": false
+      },
+      "visualforce": {
+        "refreshCacheOnLoad": true,
+        "excludeFromAllDocumentationCommand": false
+      },
+      "serviceconsole": {
+        "refreshCacheOnLoad": false,
+        "excludeFromAllDocumentationCommand": false
+      }
+    }
 }
 ```
 
 ## Key bindings
 
-Availables commands for key bindings are:
+Available commands for key bindings are:
 
-    * salesforce_apex_reference
-    * salesforce_visualforce_reference
-    * salesforce_service_console_reference
-    * salesforce_all_reference
+ - `salesforce_reference_apex`
+ - `salesforce_reference_visualforce`
+ - `salesforce_reference_service_console`
+ - `salesforce_reference_all_documentation_types`
 
-To set a key binding to one of these go to Preferences > Key Bindings - User
+To set a key binding to one of these, go to `Preferences > Key Bindings - User`
 and insert something like this:
 ``` json
 {
     "keys": ["alt+s"],
-    "command": "salesforce_all_reference"
+    "command": "salesforce_reference_all_documentation_types"
 }
 ```
 
@@ -85,6 +110,14 @@ When we're ready for a release, a release candidate will be branched off `develo
 
 If you don't follow those instructions precisely, it's probably no big deal, we'll try to make it work, but it may take longer or be more of a challenge.
 
+### Adding new documentation sources
+
+If there's a documentation source you want to add, please open an issue for discussion on why it should be included. Note that no documentation sources have been deliberately excluded yet - time to implement is the primary constraint!
+
+Alternatively, if you want to have a go at adding it yourself, `salesforce_reference/retrieve.py` contains the necessary framework for doing so:
+ - Create a new `DocRetrievalStrategy`, and add this to the `DocTypeEnum`, and `DocTypeEnum.get_all()`
+ - Add settings for this to `SublimeSalesforceReference.sublime-settings`, under `docTypes`. Make sure the key you add to this is identical to the key you added in `DocTypeEnum`, but in lowercase
+ - Add a new command in `SalesforceReference.py`, and create the command palette entry for it in `Default.sublime-commands`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ and insert something like this:
 
 If you have any suggestions or bugs to report, please open an issue and I'll take a look ASAP. If you have any questions or would like to contribute in any way, you can also get in touch with me by tweeting [@Oblongmana](http://twitter.com/oblongmana), or go ahead and fork the repo and submit a pull request.
 
-Please note that we will roughly be following semver + git-flow for 1.4.0 onwards. The short version of that is - new branches should be made off the `develop` branch like so:
+Please note that we will roughly be following semver + git-flow for 2.0.0 onwards. The short version of that is - new branches should be made off the `develop` branch like so:
  - `fix/describe-your-fix` for bug fixes
  - `feature/describe-your-feature` for new features
  - `chore/describe-your-chore` for new things like minor documentation updates

--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     //      When set to true (RECOMMENDED, and the default setting), the
     //      plugin will cache the Reference Index when Sublime Text starts
     //      or the plugin is reloaded
-    "refreshCacheOnLoad": true 
+    "refreshCacheOnLoad": true,
+    
+    // apexDoc:
+    // Setting this to false means the plugin wont download Apex
+    // reference entries
+    "apexDoc": true,
+    
+    // visualforceDoc:
+    // Setting this to false means the plugin wont download Visualforce
+    // reference entries
+    "visualforceDoc": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ SublimeSalesforceReference adds multiple new commands to your palette:
   - `Salesforce Reference - Visualforce`
   - `Salesforce Reference - Service Console`
   - `Salesforce Reference - All Documentation Types` 
+
 Simply select one of these command, and the plugin will retrieve an index of reference pages from Salesforce and show them to you in a quick panel. Search for what you're after, press enter, and the documentation page will open in your web browser!
 
 Each of the commands is reasonably self-explanatory - the `Salesforce Reference - Apex` command shows the a list of Apex documentation pages, and so on; while the `Salesforce Reference - All Documentation Types` shows in a single list the documentation for all doc types this plugin supports.
@@ -88,9 +89,10 @@ Available commands for key bindings are:
  - `salesforce_reference_all_documentation_types`
 
 To set a key binding to one of these, go to `Preferences > Key Bindings - User`
-and insert something like this:
-``` json
+and insert something like this (for example):
+``` javascript
 {
+    //Example key binding
     "keys": ["alt+s"],
     "command": "salesforce_reference_all_documentation_types"
 }

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you don't follow those instructions precisely, it's probably no big deal, we'
 If there's a documentation source you want to add, please open an issue for discussion on why it should be included. Note that no documentation sources have been deliberately excluded yet - time to implement is the primary constraint!
 
 Alternatively, if you want to have a go at adding it yourself, `salesforce_reference/retrieve.py` contains the necessary framework for doing so:
- - Create a new `DocRetrievalStrategy`, and add this to the `DocTypeEnum`, and `DocTypeEnum.get_all()`
+ - Create a new `DocRetrievalStrategy`, and add this to the `DocTypeEnum`, including modifying the `DocTypeEnum.get_all()` and `DocTypeEnum.get_by_name()` methods appropriately
  - Add settings for this to `SublimeSalesforceReference.sublime-settings`, under `docTypes`. Make sure the key you add to this is identical to the key you added in `DocTypeEnum`, but in lowercase
  - Add a new command in `SalesforceReference.py`, and create the command palette entry for it in `Default.sublime-commands`
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Availables commands for key bindings are:
 
 To set a key binding to one of these go to Preferences > Key Bindings - User
 and insert something like this:
-    ```json
-    {
-        "keys": ["alt+s"],
-        "command": "salesforce_all_reference"
-    }
-    ```
+``` json
+{
+    "keys": ["alt+s"],
+    "command": "salesforce_all_reference"
+}
+```
 
 ## Contributing, Bugs, Suggestions, Questions
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     serviceConsoleDoc: true
 }
 ```
+Availables commands for key bindings are:
+    - salesforce_apex_reference
+    - salesforce_visualforce_reference
+    - salesforce_service_console_reference
+    - salesforce_all_reference
+
+To set a key binding to one of these go to Preferences > Key Bindings - User
+and insert something like this:
+    {
+        "keys": ["alt+s"],
+        "command": "salesforce_all_reference"
+    }
 
 ## Contributing, Bugs, Suggestions, Questions
 

--- a/README.md
+++ b/README.md
@@ -48,18 +48,23 @@ To edit your settings, go to Preferences > Package Settings > Salesforce Referen
     serviceConsoleDoc: true
 }
 ```
+
+## Key bindings
+
 Availables commands for key bindings are:
-    - salesforce_apex_reference
-    - salesforce_visualforce_reference
-    - salesforce_service_console_reference
-    - salesforce_all_reference
+    1. salesforce_apex_reference
+    2. salesforce_visualforce_reference
+    3. salesforce_service_console_reference
+    4. salesforce_all_reference
 
 To set a key binding to one of these go to Preferences > Key Bindings - User
 and insert something like this:
+    ```json
     {
         "keys": ["alt+s"],
         "command": "salesforce_all_reference"
     }
+    ```
 
 ## Contributing, Bugs, Suggestions, Questions
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,20 @@ and insert something like this:
 
 If you have any suggestions or bugs to report, please open an issue and I'll take a look ASAP. If you have any questions or would like to contribute in any way, you can also get in touch with me by tweeting [@Oblongmana](http://twitter.com/oblongmana), or go ahead and fork the repo and submit a pull request.
 
+Please note that we will roughly be following semver + git-flow for 1.4.0 onwards. The short version of that is - new branches should be made off the `develop` branch like so:
+ - `fix/describe-your-fix` for bug fixes
+ - `feature/describe-your-feature` for new features
+ - `chore/describe-your-chore` for new things like minor documentation updates
+Once complete, merge any remote changes to the `develop` branch into your local branch, and submit a pull request against the `develop` branch
+
+When we're ready for a release, a release candidate will be branched off `develop` into `release-X.Y.Z` (`X.Y.Z` being the version number). This branch will be open to fixes only, no new features. Other maintenance things like release note changes, doc tweaks, will be accepted only if relevant to the release. Once complete, the release branch will be merged into master, tagged, and shipped.
+
+If you don't follow those instructions precisely, it's probably no big deal, we'll try to make it work, but it may take longer or be more of a challenge.
+
+
 ## License
 
+### Sublime Salesforce Reference
 Copyright (c) 2014-2015 James Hill <oblongmana@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
@@ -93,6 +105,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+### ThreadProgress.py
 ThreadProgress.py is licensed under the MIT license, and SalesforceReference.py's RetrieveIndexThread method derives in part from code under the same license
 
 Copyright (c) 2011-2013 Will Bond <will@wbond.net>
@@ -107,5 +120,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ## Credits
 
 All Salesforce Documentation is © Copyright 2000–2015 salesforce.com, inc.
+
+Thanks to [Marco Zeuli](https://github.com/maaaaarco) for his contributions to making extra types of documentation available in the plugin
 
 Credit to [Luke McFarlane](https://github.com/lukemcfarlane) for the inspiration!

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -5,36 +5,17 @@ __copyright__ = "SublimeSalesforceReference: (C) 2014-2015 James Hill. GNU GPL 3
 __credits__ = ["All Salesforce Documentation is © Copyright 2000–2015 salesforce.com, inc.", "ThreadProgress.py is under the MIT License, Will Bond <will@wbond.net>, and SalesforceReference.py's RetrieveIndexThread method is a derives in part from code under the same license"]
 
 import sublime, sublime_plugin
-import urllib.request
 import webbrowser
 import threading
 from queue import Queue
-import re
 # TODO: See if possible to rename the plugin while playing nice with Package
 #       Control. The current name is "sublime-salesforce-reference" - which
 #       means we can't do (for example)
 #       `import sublime-salesforce-reference.salesforce_reference.cache`
 #       as the dashes are interpreted as minuses
-from .salesforce_reference.cache import SalesforceReferenceCache,SalesforceReferenceCacheEntry
+from .salesforce_reference.cache import SalesforceReferenceCache
 from .salesforce_reference.retrieve import DocTypeEnum, DocType
 from .ThreadProgress import ThreadProgress
-
-# Import BeautifulSoup (scraping library) and html.parser
-#  - Necessary, because as at 2015-06-02 Salesforce no longer uses an XML file
-#    for generating Table of Contents, so we have to scrape a ToC out of the
-#    page itself
-#  - NB: attempting to use html5lib was horrible, due to dependence on six,
-#    which obstinately refused to work.
-#  - Built in html.parser seems perfectly adequate to needs, but if we ever
-#    support ST2, we should check for ST2 and use HTMLParser (if BeautifulSoup
-#    supports)
-#  - NB: bs4 was rebuilt (using 2to3) for Python3; we'd need to include a
-#    Python2 build if we ever support ST2
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), os.path.normpath("lib")))
-from bs4 import BeautifulSoup
-import html.parser
 
 
 #Global reference cache for holding all documentation entries

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -1,5 +1,5 @@
 """SublimeSalesforceReference: Quick access to Salesforce Documentation from Sublime Text"""
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 __author__ = "James Hill <me@jameshill.io>"
 __copyright__ = "SublimeSalesforceReference: (C) 2014-2015 James Hill. GNU GPL 3."
 __credits__ = ["All Salesforce Documentation is © Copyright 2000–2015 salesforce.com, inc.", "ThreadProgress.py is under the MIT License, Will Bond <will@wbond.net>, and SalesforceReference.py's RetrieveIndexThread method is a derives in part from code under the same license"]

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -37,11 +37,12 @@ from bs4 import BeautifulSoup
 import html.parser
 
 
-#Store all reference entries
+#Global reference cache for holding all documentation entries
 reference_cache = SalesforceReferenceCache()
 
+
 def plugin_loaded():
-    # Get settings
+    # Add settings to global, and pre-cache documentation if/as appropriate
     global settings
     settings = sublime.load_settings("SublimeSalesforceReference.sublime-settings")
     if settings != None and settings.get("refreshCacheOnLoad") == True:
@@ -70,17 +71,17 @@ class SalesforceReferenceServiceConsoleCommand(sublime_plugin.WindowCommand):
         thread.start()
         ThreadProgress(thread, "Retrieving Salesforce Service Console Reference Index...", "")
 
-# Command to retrieve all references specified in settings file
+# Command to retrieve all documentation (except for any specifically excluded by user in settings)
 class SalesforceReferenceAllDocumentationTypesCommand(sublime_plugin.WindowCommand):
     def run(self):
         thread = RetrieveIndexThread(self.window, "*")
         thread.start()
         ThreadProgress(thread, "Retrieving Salesforce Reference Index...", "")
 
-# Thread that actually download specified reference
+
 class RetrieveIndexThread(threading.Thread):
     """
-    A thread to run retrieval of the Saleforce Documentation index, or access the reference_cache
+    A thread to run retrieval of the Saleforce Documentation index, and access the reference_cache
     """
 
     def __init__(self, window, doc_type, open_when_done=True, sublime_opening_cache_refresh=False):

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -236,7 +236,7 @@ class RetrieveIndexThread(threading.Thread):
         sf_html = urllib.request.urlopen(urllib.request.Request(SALESFORCE_VISUALFORCE_DOC_URL_BASE,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
         page_soup = BeautifulSoup(sf_html, "html.parser")
         reference_soup = page_soup.find_all(text="Standard Component Reference",class_="toc-text")[0].parent.parent.parent
-        span_list = reference_soup.find_all("span", class_="toc-text", text=re.compile("^(?!Standard Component Reference)"))
+        span_list = reference_soup.find_all("span", class_="toc-text")
         for span in span_list:
             link = span.parent
             reference_cache.append(

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -30,9 +30,15 @@ sys.path.append(os.path.join(os.path.dirname(__file__), os.path.normpath("lib"))
 from bs4 import BeautifulSoup
 import html.parser
 
+#These are Salesforce official documentation links
 SALESFORCE_APEX_DOC_URL_BASE = "http://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/"
 SALESFORCE_VISUALFORCE_DOC_URL_BASE = "http://developer.salesforce.com/docs/atlas.en-us.pages.meta/pages/"
 SALESFORCE_SERVICECONSOLE_DOC_URL_BASE = "http://developer.salesforce.com/docs/atlas.en-us.api_console.meta/api_console/"
+
+#These are available documentation type
+VISUALFORCE = "visualforce"
+APEX = "apex"
+SERVICECONSOLE = "serviceconsole"
 
 class SalesforceReferenceCache(collections.MutableSequence):
     """
@@ -43,9 +49,32 @@ class SalesforceReferenceCache(collections.MutableSequence):
         self.entries = list(data)
         self.__sort_by_title()
         self.__determine_titles()
+    
+    # Properties to display entries title in quick panel
     @property
     def titles(self):
         return self.__titles
+    @property
+    def apexTitles(self):
+        return list(map(lambda entry: entry.title, self.__filter_entries(APEX)))
+    @property
+    def visualforceTitles(self):
+        return list(map(lambda entry: entry.title, self.__filter_entries(VISUALFORCE)))
+    @property
+    def serviceconsoleTitles(self):
+        return list(map(lambda entry: entry.title, self.__filter_entries(SERVICECONSOLE)))
+    
+    # Properties to return a list of filtered entries
+    @property
+    def apexEntries(self):
+        return self.__filter_entries(APEX)
+    @property
+    def visualforceEntries(self):
+        return self.__filter_entries(VISUALFORCE)
+    @property
+    def serviceconsoleEntries(self):
+        return self.__filter_entries(SERVICECONSOLE)
+    
     def __getitem__(self, key):
         return self.entries[key]
     def __setitem__(self, key, value):
@@ -65,6 +94,12 @@ class SalesforceReferenceCache(collections.MutableSequence):
         self.__determine_titles()
     def __determine_titles(self):
         self.__titles = list(map(lambda entry: entry.title,self.entries))
+    #Return a list of entries filtered by docType and ordered by title
+    def __filter_entries(self, docType):
+        entries = [entry for entry in self.entries if entry.docType == docType]
+        entries.sort(key=lambda cacheEntry: cacheEntry.title)
+        return entries
+    
     """str and repr implemented for debugging"""
     def __str__(self):
         return str(self.entries)
@@ -83,62 +118,97 @@ class SalesforceReferenceCacheEntry(object):
     def __repr__(self):
         return str({"title":self.title,"url":self.url})
 
+#Store all reference entries
 reference_cache = SalesforceReferenceCache()
 
 def plugin_loaded():
     # Get settings
-    global settings 
+    global settings
     settings = sublime.load_settings("SublimeSalesforceReference.sublime-settings")    
-    if settings != None and settings.get("refreshCacheOnLoad") == True:        
-        thread = RetrieveIndexThread(sublime.active_window(),False)
+    if settings != None and settings.get("refreshCacheOnLoad") == True:
+        thread = RetrieveIndexThread(sublime.active_window(), "all", False)        
         thread.start()
         ThreadProgress(thread, "Retrieving Salesforce Reference Index...", "")
 
 
-class SalesforceReferenceCommand(sublime_plugin.WindowCommand):
+class SalesforceApexReferenceCommand(sublime_plugin.WindowCommand):
     def run(self):
-        thread = RetrieveIndexThread(self.window)
+        thread = RetrieveIndexThread(self.window, APEX)        
+        thread.start()
+        ThreadProgress(thread, "Retrieving Salesforce Apex Reference Index...", "")
+
+class SalesforceVisualforceReferenceCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        thread = RetrieveIndexThread(self.window, VISUALFORCE)        
+        thread.start()
+        ThreadProgress(thread, "Retrieving Salesforce Visualforce Reference Index...", "")
+
+class SalesforceServiceConsoleReferenceCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        thread = RetrieveIndexThread(self.window, SERVICECONSOLE)        
+        thread.start()
+        ThreadProgress(thread, "Retrieving Salesforce Service Console Reference Index...", "")
+
+class SalesforceAllReferenceCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        thread = RetrieveIndexThread(self.window, "all")
         thread.start()
         ThreadProgress(thread, "Retrieving Salesforce Reference Index...", "")
-
 
 class RetrieveIndexThread(threading.Thread):
     """
     A thread to run retrieval of the Saleforce Documentation index, or access the reference_cache
     """
 
-    def __init__(self, window, open_when_done=True):
+    def __init__(self, window, docType, open_when_done=True):
         """
         :param window:
             An instance of :class:`sublime.Window` that represents the Sublime
             Text window to show the available package list in.
+        :param docType:
+            Specify what kind of documentation to retrieve. Accepted values are:
+                apex, retrive only apex reference entries
+                visualforce, retrieve only visualforce entries
+                serviceconsole, retrieve only service console entries
+                all, retrieve references specified in Settings file
         :param open_when_done:
             Whether this thread is being run solely for caching, or should open
             the documentation list for user selection when done. Defaults to
             true - should open the documentaton list when done
         """
         self.window = window
+        self.docType = docType
         self.open_when_done = open_when_done
         global reference_cache
         threading.Thread.__init__(self)
 
     def run(self):        
-        if not (reference_cache.entries):
-            #Check if has to get APEX doc entries            
-            if settings.get("apexDoc") == True:
+        #Check if has to get APEX doc entries            
+        if self.docType == APEX or (self.docType == "all" and settings.get("apexDoc") == True):
+            if not reference_cache.apexEntries:
                 self.__get_apex_doc()
-                            
-            #Check if has to get Visualforce doc entries
-            if settings.get("visualforceDoc") == True:
+                        
+        #Check if has to get Visualforce doc entries
+        if self.docType == VISUALFORCE or (self.docType == "all" and settings.get("visualforceDoc") == True):
+            if not reference_cache.visualforceEntries:
                 self.__get_visualforce_doc()
 
-            #Check if has to get Service Console doc entries
-            if settings.get("serviceConsoleDoc") == True:
+        #Check if has to get Service Console doc entries
+        if self.docType == SERVICECONSOLE or (self.docType == "all" and settings.get("serviceConsoleDoc") == True):
+            if not reference_cache.serviceconsoleEntries:
                 self.__get_serviceconsole_doc();
-            
+        
         if(self.open_when_done):
-            self.window.show_quick_panel(reference_cache.titles, self.open_documentation)
-    
+            #Check what kind of docs has to show
+            if (self.docType == "all"):
+                self.window.show_quick_panel(reference_cache.titles, self.open_documentation)
+            elif (self.docType == APEX):
+                self.window.show_quick_panel(reference_cache.apexTitles, self.open_documentation)
+            elif (self.docType == VISUALFORCE):
+                self.window.show_quick_panel(reference_cache.visualforceTitles, self.open_documentation)
+            elif (self.docType == SERVICECONSOLE):
+                self.window.show_quick_panel(reference_cache.serviceconsoleTitles, self.open_documentation)
+            
     #Download SERVICE CONSOLE integration toolkit doc entries
     def __get_serviceconsole_doc(self):
         sf_html = urllib.request.urlopen(urllib.request.Request(SALESFORCE_SERVICECONSOLE_DOC_URL_BASE,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
@@ -152,7 +222,7 @@ class RetrieveIndexThread(threading.Thread):
                     SalesforceReferenceCacheEntry(
                         span.string,
                         link["href"],
-                        "ServiceConsole"
+                        SERVICECONSOLE
                     )
                 )
 
@@ -168,7 +238,7 @@ class RetrieveIndexThread(threading.Thread):
                     SalesforceReferenceCacheEntry(
                         span.string,
                         link["href"],
-                        "Visualforce"
+                        VISUALFORCE
                     )
                 )
     
@@ -188,16 +258,29 @@ class RetrieveIndexThread(threading.Thread):
                     SalesforceReferenceCacheEntry(
                         header_data_tag.find(class_="toc-text").string,
                         header_data_tag["href"],
-                        "Apex"
+                        APEX
                     )
                 )
 
     def open_documentation(self, reference_index):
+        url = ""
         if(reference_index != -1):
-            # Check entry's type (Apex or Visualforce)
-            if reference_cache[reference_index].docType == "Apex":
-                webbrowser.open_new_tab(SALESFORCE_APEX_DOC_URL_BASE + reference_cache[reference_index].url)
-            elif reference_cache[reference_index].docType == "Visualforce":
-                webbrowser.open_new_tab(SALESFORCE_VISUALFORCE_DOC_URL_BASE + reference_cache[reference_index].url)
-            elif reference_cache[reference_index].docType == "ServiceConsole"
-                webbrowser.open_new_tab(SALESFORCE_SERVICECONSOLE_DOC_URL_BASE + reference_cache[reference_index].url)
+            if self.docType == APEX:
+                entry = reference_cache.apexEntries[reference_index]
+            elif self.docType == VISUALFORCE:
+                entry = reference_cache.visualforceEntries[reference_index]
+            elif self.docType == SERVICECONSOLE:
+                entry = reference_cache.serviceconsoleEntries[reference_index]
+            elif self.docType == "all":
+                entry = reference_cache[reference_index]
+            
+            if entry:
+                if entry.docType == APEX:
+                    url = SALESFORCE_APEX_DOC_URL_BASE + entry.url
+                elif entry.docType == VISUALFORCE:
+                    url = SALESFORCE_VISUALFORCE_DOC_URL_BASE + entry.url
+                elif entry.docType == SERVICECONSOLE:
+                    url = SALESFORCE_SERVICECONSOLE_DOC_URL_BASE + entry.url
+            
+            if url:
+                webbrowser.open_new_tab(url)

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -1,5 +1,5 @@
 """SublimeSalesforceReference: Quick access to Salesforce Documentation from Sublime Text"""
-__version__ = "1.5.0"
+__version__ = "2.0.0"
 __author__ = "James Hill <me@jameshill.io>"
 __copyright__ = "SublimeSalesforceReference: (C) 2014-2015 James Hill. GNU GPL 3."
 __credits__ = ["All Salesforce Documentation is © Copyright 2000–2015 salesforce.com, inc.", "ThreadProgress.py is under the MIT License, Will Bond <will@wbond.net>, and SalesforceReference.py's RetrieveIndexThread method is a derives in part from code under the same license"]

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -49,7 +49,7 @@ class SalesforceReferenceCache(collections.MutableSequence):
         self.entries = list(data)
         self.__sort_by_title()
         self.__determine_titles()
-    
+
     # Properties to display entry's titles in quick panel
     @property
     def titles(self):
@@ -63,7 +63,7 @@ class SalesforceReferenceCache(collections.MutableSequence):
     @property
     def serviceconsoleTitles(self):
         return list(map(lambda entry: entry.title, self.__filter_entries(SERVICECONSOLE)))
-    
+
     # Properties to return a list of filtered entries
     @property
     def apexEntries(self):
@@ -74,7 +74,7 @@ class SalesforceReferenceCache(collections.MutableSequence):
     @property
     def serviceconsoleEntries(self):
         return self.__filter_entries(SERVICECONSOLE)
-    
+
     def __getitem__(self, key):
         return self.entries[key]
     def __setitem__(self, key, value):
@@ -220,7 +220,6 @@ class RetrieveIndexThread(threading.Thread):
         reference_soup = page_soup.find_all("span", text=re.compile("Methods for \w"), class_="toc-text")
         for reference in reference_soup:
             span_list = reference.parent.parent.parent.find_all("span", class_="toc-text", text=re.compile("^(?!Methods for)"))
-            print("span list is:", span_list)
             for span in span_list:
                 link = span.parent
                 reference_cache.append(

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -1,6 +1,6 @@
 """SublimeSalesforceReference: Quick access to Salesforce Documentation from Sublime Text"""
 __version__ = "1.4.0"
-__author__ = "James Hill (oblongmana@gmail.com)"
+__author__ = "James Hill <me@jameshill.io>"
 __copyright__ = "SublimeSalesforceReference: (C) 2014-2015 James Hill. GNU GPL 3."
 __credits__ = ["All Salesforce Documentation is © Copyright 2000–2015 salesforce.com, inc.", "ThreadProgress.py is under the MIT License, Will Bond <will@wbond.net>, and SalesforceReference.py's RetrieveIndexThread method is a derives in part from code under the same license"]
 

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -142,12 +142,15 @@ class RetrieveIndexThread(threading.Thread):
         url = ""
         if(reference_index != -1):
             if self.doc_type == "*":
-                entry = reference_cache[reference_index]
+                entry = reference_cache.entries[reference_index]
             else:
                 entry = reference_cache.entries_by_doc_type.get(self.doc_type.name)[reference_index]
 
             if entry:
-                url = self.doc_type.url + entry.url
+                if self.doc_type == "*":
+                    url = DocTypeEnum.get_by_name(entry.doc_type).url + entry.url
+                else:
+                    url = self.doc_type.url + entry.url
 
             if url:
                 webbrowser.open_new_tab(url)

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ElementTree
 import webbrowser
 import threading
 import collections
+import re
 from .ThreadProgress import ThreadProgress
 
 # Import BeautifulSoup (scraping library) and html.parser
@@ -140,8 +141,20 @@ class RetrieveIndexThread(threading.Thread):
     
     #Download SERVICE CONSOLE integration toolkit doc entries
     def __get_serviceconsole_doc(self):
-        #Work in progress
-        pass
+        sf_html = urllib.request.urlopen(urllib.request.Request(SALESFORCE_SERVICECONSOLE_DOC_URL_BASE,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
+        page_soup = BeautifulSoup(sf_html, "html.parser")
+        reference_soup = page_soup.find_all("span", string=re.compile("Methods for \w"), class_="toc-text")
+        for reference in reference_soup:
+            span_list = reference.parent.parent.parent.find_all("span", class_="toc-text", string=re.compile("^(?!Methods for)"))
+            for span in span_list:
+                link = span.parent
+                reference_cache.append(
+                    SalesforceReferenceCacheEntry(
+                        span.string,
+                        link["href"],
+                        "ServiceConsole"
+                    )
+                )
 
     #Download VISUALFORCE doc entries
     def __get_visualforce_doc(self):        
@@ -186,3 +199,5 @@ class RetrieveIndexThread(threading.Thread):
                 webbrowser.open_new_tab(SALESFORCE_APEX_DOC_URL_BASE + reference_cache[reference_index].url)
             elif reference_cache[reference_index].docType == "Visualforce":
                 webbrowser.open_new_tab(SALESFORCE_VISUALFORCE_DOC_URL_BASE + reference_cache[reference_index].url)
+            elif reference_cache[reference_index].docType == "ServiceConsole"
+                webbrowser.open_new_tab(SALESFORCE_SERVICECONSOLE_DOC_URL_BASE + reference_cache[reference_index].url)

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -6,7 +6,6 @@ __credits__ = ["All Salesforce Documentation is © Copyright 2000–2015 salesfo
 
 import sublime, sublime_plugin
 import urllib.request
-import xml.etree.ElementTree as ElementTree
 import webbrowser
 import threading
 import re

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -20,6 +20,7 @@ from .ThreadProgress import ThreadProgress
 
 #Global reference cache for holding all documentation entries
 reference_cache = SalesforceReferenceCache()
+cache_lock = threading.Lock()
 
 
 def plugin_loaded():
@@ -110,8 +111,6 @@ class RetrieveIndexThread(threading.Thread):
         threading.Thread.__init__(self)
 
     def run(self):
-        cache_lock = threading.Lock()
-
         if self.doc_type == "*":
             for doc_type in DocTypeEnum.get_all():
                 doc_type_settings = settings.get("docTypes").get(doc_type.name.lower())

--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -115,6 +115,8 @@ class RetrieveIndexThread(threading.Thread):
         threading.Thread.__init__(self)
 
     def run(self):
+        cache_lock = threading.Lock()
+
         if self.doc_type == "*":
             doc_type_settings = settings.get("docTypes")
             for doc_type in DocTypeEnum.get_all():
@@ -122,10 +124,10 @@ class RetrieveIndexThread(threading.Thread):
                         not doc_type_settings.get(doc_type.name.lower()).get('excludeFromAllDocumentationCommand')
                         and not reference_cache.entries_by_doc_type.get(doc_type.name)
                     ):
-                    self.queue.put(doc_type.preferred_strategy(self.window,reference_cache,self.queue.task_done))
+                    self.queue.put(doc_type.preferred_strategy(self.window,reference_cache,cache_lock,self.queue.task_done))
         else:
             if not reference_cache.entries_by_doc_type.get(self.doc_type.name):
-                self.queue.put(self.doc_type.preferred_strategy(self.window,reference_cache,self.queue.task_done))
+                self.queue.put(self.doc_type.preferred_strategy(self.window,reference_cache,cache_lock,self.queue.task_done))
 
         while not self.queue.empty():
             self.queue.get().start()

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -18,5 +18,10 @@
     // visualforceDoc:
     // Setting this to false means the plugin wont download Visualforce
     // reference entries
-    "visualforceDoc": false 
+    "visualforceDoc": false,
+    
+    // serviceConsoleDoc:
+    // Setting this to false means the plugin wont download Service Console
+    // Javascript toolkit reference entries
+    serviceConsoleDoc: false
 }

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -23,5 +23,5 @@
     // serviceConsoleDoc:
     // Setting this to false means the plugin wont download Service Console
     // Javascript toolkit reference entries
-    serviceConsoleDoc: false
+    "serviceConsoleDoc": false
 }

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -8,20 +8,39 @@
     //      When set to true (RECOMMENDED, and the default setting), the
     //      plugin will cache the Reference Index when Sublime Text starts
     //      or the plugin is reloaded
-    "refreshCacheOnLoad": true,
-    
-    // apexDoc:
-    // Setting this to false means the plugin wont download Apex
-    // reference entries
-    "apexDoc": true,
-    
-    // visualforceDoc:
-    // Setting this to false means the plugin wont download Visualforce
-    // reference entries
-    "visualforceDoc": false,
-    
-    // serviceConsoleDoc:
-    // Setting this to false means the plugin wont download Service Console
-    // Javascript toolkit reference entries
-    "serviceConsoleDoc": false
+    "refreshCacheOnLoad": false,
+
+    //  docTypes:
+    //
+    //  Each docType has one option:
+    //   - refreshCacheOnLoad:
+    //       if the top-level refreshCacheOnLoad setting is true, and this
+    //       docType's refreshCacheOnLoad setting is true - this documentation
+    //       type will be cache when sublime starts up. Otherwise, this
+    //       documentation type will only be retrieved and cached when it's
+    //       corresponding command is run
+    //   - excludeFromAllDocumentationCommand:
+    //       if this is set to true, the command "Salesforce Reference - All
+    //       Documentation Types" will not include this documentation type.
+    //       If set to false for a documentation type, uou'll only be able to
+    //       view that documentation type with from the command specific to it,
+    //       it won't be included in the command "Salesforce Reference - All
+    //       Documentation Types"
+    //
+    //  Note to developers: the keys in `docTypes` should be an exact lowercase
+    //   match of one of the keys in salesforce_reference.retrieve.DocTypeEnum
+    "docTypes": {
+      "apex": {
+        "refreshCacheOnLoad": true,
+        "excludeFromAllDocumentationCommand": false
+      },
+      "visualforce": {
+        "refreshCacheOnLoad": false,
+        "excludeFromAllDocumentationCommand": false
+      },
+      "serviceconsole": {
+        "refreshCacheOnLoad": false,
+        "excludeFromAllDocumentationCommand": false
+      }
+    }
 }

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -8,5 +8,15 @@
     //      When set to true (RECOMMENDED, and the default setting), the
     //      plugin will cache the Reference Index when Sublime Text starts
     //      or the plugin is reloaded
-    "refreshCacheOnLoad": true 
+    "refreshCacheOnLoad": true,
+    
+    // apexDoc:
+    // Setting this to false means the plugin wont download Apex
+    // reference entries
+    "apexDoc": true,
+    
+    // visualforceDoc:
+    // Setting this to false means the plugin wont download Visualforce
+    // reference entries
+    "visualforceDoc": false 
 }

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -1,41 +1,46 @@
 {
-    //  refreshCacheOnLoad:
-    //
-    //  Setting this to false means the plugin will need to do a callout
-    //      to retrieve the Salesforce Reference Index from Salesforce
-    //      when the *Salesforce Reference* command is first run.
-    //
-    //      When set to true (RECOMMENDED, and the default setting), the
-    //      plugin will cache the Reference Index when Sublime Text starts
-    //      or the plugin is reloaded
-    "refreshCacheOnLoad": false,
+    /**
+     * refreshCacheOnLoad:
+     *
+     * Setting this to false means the plugin will need to do a callout
+     *     to retrieve the Salesforce Reference Index from Salesforce
+     *     when the *Salesforce Reference* command is first run.
+     *
+     *     When set to true (RECOMMENDED, and the default setting), the
+     *     plugin will cache the Reference Index when Sublime Text starts
+     *     or the plugin is reloaded. This happens asynchronously, and will not
+     *     prevent you from doing other work in Sublime
+     */
+    "refreshCacheOnLoad": true,
 
-    //  docTypes:
-    //
-    //  Each docType has one option:
-    //   - refreshCacheOnLoad:
-    //       if the top-level refreshCacheOnLoad setting is true, and this
-    //       docType's refreshCacheOnLoad setting is true - this documentation
-    //       type will be cache when sublime starts up. Otherwise, this
-    //       documentation type will only be retrieved and cached when it's
-    //       corresponding command is run
-    //   - excludeFromAllDocumentationCommand:
-    //       if this is set to true, the command "Salesforce Reference - All
-    //       Documentation Types" will not include this documentation type.
-    //       If set to false for a documentation type, uou'll only be able to
-    //       view that documentation type with from the command specific to it,
-    //       it won't be included in the command "Salesforce Reference - All
-    //       Documentation Types"
-    //
-    //  Note to developers: the keys in `docTypes` should be an exact lowercase
-    //   match of one of the keys in salesforce_reference.retrieve.DocTypeEnum
+    /**
+     *  docTypes:
+     *
+     *  Each docType has one option:
+     *   - refreshCacheOnLoad:
+     *       if the top-level refreshCacheOnLoad setting is true, and this
+     *       docType's refreshCacheOnLoad setting is true - this documentation
+     *       type will be cache when sublime starts up. Otherwise, this
+     *       documentation type will only be retrieved and cached when it's
+     *       corresponding command is run
+     *   - excludeFromAllDocumentationCommand:
+     *       if this is set to true, the command "Salesforce Reference - All
+     *       Documentation Types" will not include this documentation type.
+     *       If set to false for a documentation type, uou'll only be able to
+     *       view that documentation type with from the command specific to it,
+     *       it won't be included in the command "Salesforce Reference - All
+     *       Documentation Types"
+     *
+     *  Note to developers: the keys in `docTypes` should be an exact lowercase
+     *   match of one of the keys in salesforce_reference.retrieve.DocTypeEnum
+     */
     "docTypes": {
       "apex": {
         "refreshCacheOnLoad": true,
         "excludeFromAllDocumentationCommand": false
       },
       "visualforce": {
-        "refreshCacheOnLoad": false,
+        "refreshCacheOnLoad": true,
         "excludeFromAllDocumentationCommand": false
       },
       "serviceconsole": {

--- a/messages.json
+++ b/messages.json
@@ -7,5 +7,5 @@
   "1.2.0": "messages/1.2.0.txt",
   "1.3.0": "messages/1.3.0.txt",
   "1.4.0": "messages/1.4.0.txt",
-  "1.5.0": "messages/1.5.0.txt"
+  "2.0.0": "messages/2.0.0.txt"
 }

--- a/messages.json
+++ b/messages.json
@@ -6,5 +6,6 @@
   "1.1.1": "messages/1.1.1.txt",
   "1.2.0": "messages/1.2.0.txt",
   "1.3.0": "messages/1.3.0.txt",
-  "1.4.0": "messages/1.4.0.txt"
+  "1.4.0": "messages/1.4.0.txt",
+  "1.5.0": "messages/1.5.0.txt"
 }

--- a/messages/1.5.0.txt
+++ b/messages/1.5.0.txt
@@ -1,5 +1,0 @@
-Sublime Salesforce Reference 1.5.0 Release Notes:
-
-Enhancements:
-  - Add other docs
-    - TODO: flesh this out

--- a/messages/1.5.0.txt
+++ b/messages/1.5.0.txt
@@ -1,0 +1,5 @@
+Sublime Salesforce Reference 1.5.0 Release Notes:
+
+Enhancements:
+  - Add other docs
+    - TODO: flesh this out

--- a/messages/2.0.0.txt
+++ b/messages/2.0.0.txt
@@ -1,0 +1,51 @@
+Sublime Salesforce Reference 2.0.0 Release Notes:
+
+This release adds new types of documentation - so not only do you have access
+to Apex doc, you can now access Visualforce and Service Console docs!
+
+This is marked as a major release, due to some changes that could potentially
+break some configuration for existing users. This will be very minor - only a
+renamed command. See the end of these release notes for details.
+
+
+Enhancements:
+  - Add new documentation types (thanks to Marco Zeuli
+     [https://github.com/maaaaarco]) for his significant contribution to this
+     feature. Each documentation type is available individually under new
+     commands, and will present a list of links that open in browser, just
+     like the old command:
+    + "Salesforce Reference - Apex"
+    + "Salesforce Reference - Visualforce"
+    + "Salesforce Reference - Service Console"
+    + "Salesforce Reference - All Documentation Types": this special command
+        shows a list containing all of the documentation links for all of the
+        different documentation types, mashed into one single list.
+
+  - Each of the new documentation types has corresponding settings in your
+     settings file (`Preferences > Package Settings > Salesforce Reference >
+     Settings - User` - copy from `Settings - Default` if these are missing).
+     For each documentation type, you can control:
+    + `refreshCacheOnLoad`: the top level `refreshCacheOnLoad` setting still
+        controls whether to retrieve and cache documentation at all during
+        Sublime startup, but during that process, the plugin will check each
+        `docType`s setting to see whether a specific Documentation type gets
+        cached during startup or not (the default is to cache Apex and
+        Visualforce during startup, but not Service Console).
+    + `excludeFromAllDocumentationCommand`: if you set this to true for a
+        particular `docType` - the "Salesforce Reference - All Documentation
+        Types" command will exclude this doc type from its list.
+
+  - Threading has been improved to support this new system - doc retrieval jobs
+     can run at the same time, important for retrieving multiple docs at once.
+     This is not likely to have significant impact on you - the end user - but
+     it's nice to have, trust us :D
+
+Breaking Changes:
+  - The old "Salesforce Reference" command (`salesforce_reference`) no longer
+     exists. The equivalent new command is "Salesforce Reference - Apex"
+     (`salesforce_reference_apex`) - as the old command only retrieved Apex
+     documentation.
+    + This change should only be important for users who have set up a key
+        binding for the command - if that's you, simply replace
+        `salesforce_reference` with `salesforce_reference_apex` in your key
+        bindings

--- a/messages/install.txt
+++ b/messages/install.txt
@@ -13,7 +13,7 @@ SublimeSalesforceReference adds a new command to your palette: *'Salesforce Refe
 
 ## License
 
-Copyright (c) 2014-2015 James Hill <oblongmana@gmail.com>
+Copyright (c) 2014-2015 James Hill <me@jameshill.io>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/salesforce_reference/cache.py
+++ b/salesforce_reference/cache.py
@@ -58,12 +58,6 @@ class SalesforceReferenceCache(collections.MutableSequence):
     def __index_titles_by_doc_type(self):
         self.__titles_by_doc_type = {title_key: self.__extract_titles_from_list(sorted(list(entry)))
                                      for title_key, entry in self.__groupby(sorted(self.__entries),lambda entry: entry.doc_type)}
-    #Return a list of entries filtered by doc_type and ordered by title
-    # TODO: can probably remove this
-    def __filter_entries(self, doc_type):
-        entries = [entry for entry in self.__entries if entry.doc_type == doc_type]
-        entries.sort(key=lambda cacheEntry: cacheEntry.title)
-        return entries
     def __groupby(self, the_list, key=lambda x: x):
         # From http://stackoverflow.com/a/15250161/157556
         # itertools.groupby didn't play nice with custom sorting

--- a/salesforce_reference/cache.py
+++ b/salesforce_reference/cache.py
@@ -1,0 +1,95 @@
+import collections
+from functools import total_ordering
+from itertools import groupby
+
+class SalesforceReferenceCache(collections.MutableSequence):
+    """
+    A cache of SalesforceReferenceEntry objects, sorted by Title. This order
+    will be maintained throughout append operations
+    """
+    def __init__(self, *data):
+        self.__entries = list(data)
+        self.__entries_by_doc_type = {}
+        self.__titles_by_doc_type = {}
+        self.__maintain_cache()
+
+    # Properties for quick access to cached info
+
+    @property
+    def entries(self):
+        return self.__entries
+
+    @property
+    def titles(self):
+        return self.__titles
+
+    @property
+    def titles_by_doc_type(self):
+        return self.__titles_by_doc_type
+
+    @property
+    def entries_by_doc_type(self):
+        return self.__entries_by_doc_type
+
+    def __getitem__(self, key):
+        return self.__entries[key]
+    # TODO: determine how adding and deleting affects the items cached in
+    #   __titles_by_doc_type and __entries_by_doc_type
+    def __setitem__(self, key, value):
+        self.__entries[key] = value
+        self.__maintain_cache()
+    def __delitem__(self, key):
+        del self.__entries[key]
+        self.__maintain_cache()
+    def __len__(self):
+        return len(self.__entries)
+    def insert(self, key,val):
+        self.__entries.insert(key,val)
+        self.__maintain_cache()
+    def __maintain_cache(self):
+        self.__entries.sort()
+        self.__index_entries_by_doc_type()
+        self.__index_titles_by_doc_type()
+        self.__determine_titles()
+    def __index_entries_by_doc_type(self):
+        self.__entries_by_doc_type = {title_key: sorted(list(entry))
+                                        for title_key, entry in groupby(sorted(self.__entries),lambda entry: entry.doc_type)}
+    def __extract_titles_from_list(self,the_list):
+        return list(map(lambda entry: entry.title,the_list))
+    def __determine_titles(self):
+        self.__titles = self.__extract_titles_from_list(self.__entries)
+    def __index_titles_by_doc_type(self):
+        self.__titles_by_doc_type = {title_key: self.__extract_titles_from_list(sorted(list(entry)))
+                                     for title_key, entry in groupby(sorted(self.__entries),lambda entry: entry.doc_type)}
+    #Return a list of entries filtered by doc_type and ordered by title
+    def __filter_entries(self, doc_type):
+        entries = [entry for entry in self.__entries if entry.doc_type == doc_type]
+        entries.sort(key=lambda cacheEntry: cacheEntry.title)
+        return entries
+
+    """str and repr implemented for debugging"""
+    def __str__(self):
+        return str(self.__entries)
+    def __repr__(self):
+        return repr(self.__entries)
+
+@total_ordering
+class SalesforceReferenceCacheEntry(object):
+    def __init__(self,title,url,doc_type):
+        self.title = title
+        self.url = url
+        # Specify entry's type. Based on this value, change the doc base url
+        self.doc_type = doc_type
+    """required functions for use with sort() and sorted()"""
+    """the total_ordering annotation supplies remaining comparison functions"""
+    def __eq__(self, other):
+        return ((self.title.lower(), self.doc_type.lower()) ==
+                (other.title.lower(), other.doc_type.lower()))
+    def __lt__(self, other):
+        return ((self.title.lower(), self.doc_type.lower()) <
+                (other.title.lower(), other.doc_type.lower()))
+    """str and repr implemented for debugging"""
+    def __str__(self):
+        return str({"title":self.title,"url":self.url,"doc_type":self.doc_type})
+    def __repr__(self):
+        return str({"title":self.title,"url":self.url,"doc_type":self.doc_type})

--- a/salesforce_reference/cache.py
+++ b/salesforce_reference/cache.py
@@ -77,7 +77,6 @@ class SalesforceReferenceCacheEntry(object):
     def __init__(self,title,url,doc_type):
         self.title = title
         self.url = url
-        # Specify entry's type. Based on this value, change the doc base url
         self.doc_type = doc_type
     """required functions for use with sort() and sorted()"""
     """the total_ordering annotation supplies remaining comparison functions"""

--- a/salesforce_reference/retrieve.py
+++ b/salesforce_reference/retrieve.py
@@ -1,0 +1,169 @@
+import threading
+import urllib.request
+import re
+from .cache import SalesforceReferenceCacheEntry
+# Import BeautifulSoup (scraping library) and html.parser
+#  - Necessary, because as at 2015-06-02 Salesforce no longer uses an XML file
+#    for generating Table of Contents, so we have to scrape a ToC out of the
+#    page itself
+#  - NB: attempting to use html5lib was horrible, due to dependence on six,
+#    which obstinately refused to work.
+#  - Built in html.parser seems perfectly adequate to needs, but if we ever
+#    support ST2, we should check for ST2 and use HTMLParser (if BeautifulSoup
+#    supports)
+#  - NB: bs4 was rebuilt (using 2to3) for Python3; we'd need to include a
+#    Python2 build if we ever support ST2
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.path.normpath("lib")))
+from bs4 import BeautifulSoup
+import html.parser
+
+class DocRetrievalStrategy(threading.Thread):
+    def __init__(self, window, cache, done_callback):
+        """
+        :param window:
+            An instance of :class:`sublime.Window` that represents the Sublime
+            Text window to show the available package list in.
+        :cache
+            an instance of SalesforceReferenceCache
+        :done_callback
+            a function to call when the thread is done running. This would
+            generally be something like a `Queue` instance's `task_done` method
+        """
+        self.window = window
+        self.cache = cache
+        self.done_callback = done_callback
+        threading.Thread.__init__(self)
+
+    @property
+    def doc_type(self):
+        raise NotImplementedError(
+                "SalesforceDocRetrievalStrategy is an interface, implementing "
+                "classes should override `doc_type` to return an appropriate "
+                " string indicating the doc type (e.g. 'VISUALFORCE') "
+            )
+
+    def run(self):
+        raise NotImplementedError(
+                "SalesforceDocRetrievalStrategy is an interface, implementing "
+                "classes should override `run` to do the appropriate scraping "
+                "of required documentation, and cache population "
+            )
+
+
+class ApexDocScrapingStrategy(DocRetrievalStrategy):
+    def __init__(self, window, cache, done_callback):
+        DocRetrievalStrategy.__init__(self, window, cache, done_callback)
+
+    @property
+    def doc_type(self):
+        return DocTypeEnum.APEX.name
+
+    def run(self):
+        sf_html = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.APEX.url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
+        page_soup = BeautifulSoup(sf_html, "html.parser")
+        reference_soup = page_soup.find_all(text="Reference",class_="toc-text")[0].parent.parent.next_sibling
+        leaf_soup_list = reference_soup.find_all(class_="leaf")
+        header_soup_list = map(lambda leaf: leaf.parent.previous_sibling,leaf_soup_list)
+        unique_header_soup_list = list()
+        for header_soup in header_soup_list:
+            if header_soup not in unique_header_soup_list:
+                unique_header_soup_list.append(header_soup)
+                header_data_tag = header_soup.find(class_="toc-a-block")
+                self.cache.append(
+                    SalesforceReferenceCacheEntry(
+                        header_data_tag.find(class_="toc-text").string,
+                        header_data_tag["href"],
+                        DocTypeEnum.APEX.name
+                    )
+                )
+        self.done_callback()
+
+class VisualforceDocScrapingStrategy(DocRetrievalStrategy):
+    def __init__(self, window, cache, done_callback):
+        DocRetrievalStrategy.__init__(self, window, cache, done_callback)
+
+    @property
+    def doc_type(self):
+        return DocTypeEnum.VISUALFORCE.name
+
+    def run(self):
+        sf_html = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.VISUALFORCE.url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
+        page_soup = BeautifulSoup(sf_html, "html.parser")
+        reference_soup = page_soup.find_all(text="Standard Component Reference",class_="toc-text")[0].parent.parent.parent
+        span_list = reference_soup.find_all("span", class_="toc-text")
+        for span in span_list:
+            link = span.parent
+            self.cache.append(
+                    SalesforceReferenceCacheEntry(
+                        span.string,
+                        link["href"],
+                        DocTypeEnum.VISUALFORCE.name
+                    )
+                )
+        self.done_callback()
+
+class ServiceConsoleDocScrapingStrategy(DocRetrievalStrategy):
+    def __init__(self, window, cache, done_callback):
+        DocRetrievalStrategy.__init__(self, window, cache, done_callback)
+
+    @property
+    def doc_type(self):
+        return DocTypeEnum.SERVICECONSOLE.name
+
+    def run(self):
+        sf_html = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.SERVICECONSOLE.url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
+        page_soup = BeautifulSoup(sf_html, "html.parser")
+        reference_soup = page_soup.find_all("span", text=re.compile("Methods for \w"), class_="toc-text")
+        for reference in reference_soup:
+            span_list = reference.parent.parent.parent.find_all("span", class_="toc-text", text=re.compile("^(?!Methods for)"))
+            for span in span_list:
+                link = span.parent
+                self.cache.append(
+                    SalesforceReferenceCacheEntry(
+                        span.string,
+                        link["href"],
+                        DocTypeEnum.SERVICECONSOLE.name
+                    )
+                )
+        self.done_callback()
+
+class DocType:
+    def __init__(self, name, url, preferred_strategy):
+        self.__name = name
+        self.__url = url
+        self.__preferred_strategy = preferred_strategy
+    @property
+    def name(self):
+        return self.__name
+    @property
+    def url(self):
+        return self.__url
+    @property
+    def preferred_strategy(self):
+        return self.__preferred_strategy
+
+class DocTypeEnum:
+    VISUALFORCE = DocType(
+            "VISUALFORCE",
+            "http://developer.salesforce.com/docs/atlas.en-us.pages.meta/pages/",
+            VisualforceDocScrapingStrategy
+        )
+    APEX = DocType(
+            "APEX",
+            "http://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/",
+            ApexDocScrapingStrategy
+        )
+    SERVICECONSOLE = DocType(
+            "SERVICECONSOLE",
+            "http://developer.salesforce.com/docs/atlas.en-us.api_console.meta/api_console/",
+            ServiceConsoleDocScrapingStrategy
+        )
+    @staticmethod
+    def get_all():
+        return [
+            DocTypeEnum.VISUALFORCE,
+            DocTypeEnum.APEX,
+            DocTypeEnum.SERVICECONSOLE
+        ]

--- a/salesforce_reference/retrieve.py
+++ b/salesforce_reference/retrieve.py
@@ -174,3 +174,11 @@ class DocTypeEnum:
             DocTypeEnum.APEX,
             DocTypeEnum.SERVICECONSOLE
         ]
+    @staticmethod
+    def get_by_name(name):
+        if name == DocTypeEnum.VISUALFORCE.name:
+            return DocTypeEnum.VISUALFORCE
+        elif name == DocTypeEnum.APEX.name:
+            return DocTypeEnum.APEX
+        elif name == DocTypeEnum.SERVICECONSOLE.name:
+            return DocTypeEnum.SERVICECONSOLE

--- a/salesforce_reference/retrieve.py
+++ b/salesforce_reference/retrieve.py
@@ -27,6 +27,8 @@ class DocRetrievalStrategy(threading.Thread):
             Text window to show the available package list in.
         :cache
             an instance of SalesforceReferenceCache
+        :cache_lock
+            a threading.Lock to be used when modifying the cache
         :done_callback
             a function to call when the thread is done running. This would
             generally be something like a `Queue` instance's `task_done` method
@@ -42,7 +44,8 @@ class DocRetrievalStrategy(threading.Thread):
         raise NotImplementedError(
                 "SalesforceDocRetrievalStrategy is an interface, implementing "
                 "classes should override `doc_type` to return an appropriate "
-                " string indicating the doc type (e.g. 'VISUALFORCE') "
+                "string indicating the doc type (e.g. "
+                "DocTypeEnum.VISUALFORCE.name) "
             )
 
     def run(self):


### PR DESCRIPTION
Extra Doc Types have now been added. @maaaaarco I've tweaked your implementation a fair amount - including a bit of abstraction I'd been wanting to add. The core is still there, and I haven't touched your scraper routines - just shuffled them to a different location.

Recommend have a look in `messages/2.0.0.txt` for a summary of the changes, from the end user perspective.

With this PR, I've also changed the primary branch for the repo to `develop`, and added some notes to the README re using git-flow

Main changes:
 - Extra Doc Types added
 - Cache logic moved to `salesforce_reference/cache.py`
 - Retrieval logic moved to `salesforce_reference/retrieve.py`
 - Different retrievals can run simultaneously, and lock the cache when editing it (to prevent threading nasties from creeping out)
 - Settings added to allow per doc type control over:
  - whether the doc type is cached during sublime startup
  - whether the doc type shows in the "All Documentation Types" command
 - Prep work for 2.0.0 release - writing release notes, changing ver numbers, updating contributing information
 

This at least partially deals to #10, and includes @maaaaarco 's work from #9 