### PR TITLE
Write new JSON ToC based retrievals

### DIFF
--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -162,9 +162,9 @@ class RetrieveIndexThread(threading.Thread):
 
             if entry:
                 if self.doc_type == "*":
-                    url = DocTypeEnum.get_by_name(entry.doc_type).url + entry.url
+                    url = DocTypeEnum.get_by_name(entry.doc_type).doc_base_url + entry.url
                 else:
-                    url = self.doc_type.url + entry.url
+                    url = self.doc_type.doc_base_url + entry.url
 
             if url:
                 webbrowser.open_new_tab(url)

--- a/salesforce_reference/retrieve.py
+++ b/salesforce_reference/retrieve.py
@@ -13,10 +13,11 @@ from .cache import SalesforceReferenceCacheEntry
 #    supports)
 #  - NB: bs4 was rebuilt (using 2to3) for Python3; we'd need to include a
 #    Python2 build if we ever support ST2
-import sys
+import sys, traceback
 import os
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.path.normpath("lib")))
 from bs4 import BeautifulSoup
+import json
 import html.parser
 
 class DocRetrievalStrategy(threading.Thread):
@@ -55,8 +56,20 @@ class DocRetrievalStrategy(threading.Thread):
                 "of required documentation, and cache population "
             )
 
+    def logRetrievalException(self):
+        print("######### Sublime Salesforce Reference Error #########")
+        print("Fatal error in Sublime Salesforce Reference while retrieving doc. Please report this on https://github.com/Oblongmana/sublime-salesforce-reference/issues. Error info follows:")
+        print(traceback.format_exc())
+        with self.cache_lock:
+            self.cache.append(
+                SalesforceReferenceCacheEntry(
+                    'Error retrieving doc. Press Cmd/Ctrl+` for details, and report the error on github',
+                    '',
+                    self.doc_type
+                )
+            )
 
-class ApexDocScrapingStrategy(DocRetrievalStrategy):
+class ApexDocJsonTocBasedStrategy(DocRetrievalStrategy):
     def __init__(self, window, cache, cache_lock, done_callback):
         DocRetrievalStrategy.__init__(self, window, cache, cache_lock, done_callback)
 
@@ -65,27 +78,26 @@ class ApexDocScrapingStrategy(DocRetrievalStrategy):
         return DocTypeEnum.APEX.name
 
     def run(self):
-        sf_html = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.APEX.url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
-        page_soup = BeautifulSoup(sf_html, "html.parser")
-        reference_soup = page_soup.find_all(text="Reference",class_="toc-text")[0].parent.parent.next_sibling
-        leaf_soup_list = reference_soup.find_all(class_="leaf")
-        header_soup_list = map(lambda leaf: leaf.parent.previous_sibling,leaf_soup_list)
-        unique_header_soup_list = list()
-        for header_soup in header_soup_list:
-            if header_soup not in unique_header_soup_list:
-                unique_header_soup_list.append(header_soup)
-                header_data_tag = header_soup.find(class_="toc-a-block")
+        try:
+            sf_document = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.APEX.toc_url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
+            sf_json = json.loads(sf_document)
+            sf_toc = sf_json["toc"]
+            reference_toc = filter(lambda x: "id" in x and x["id"] == "apex_reference", sf_toc)
+            for toc_entry in getAllTocLeafParents(next(reference_toc),None):
                 with self.cache_lock:
                     self.cache.append(
                         SalesforceReferenceCacheEntry(
-                            header_data_tag.find(class_="toc-text").string,
-                            header_data_tag["href"],
+                            toc_entry["text"],
+                            toc_entry["a_attr"]["href"],
                             DocTypeEnum.APEX.name
                         )
                     )
+        except Exception as e:
+            self.logRetrievalException();
+
         self.done_callback()
 
-class VisualforceDocScrapingStrategy(DocRetrievalStrategy):
+class VisualforceDocJsonTocBasedStrategy(DocRetrievalStrategy):
     def __init__(self, window, cache, cache_lock, done_callback):
         DocRetrievalStrategy.__init__(self, window, cache, cache_lock, done_callback)
 
@@ -94,23 +106,27 @@ class VisualforceDocScrapingStrategy(DocRetrievalStrategy):
         return DocTypeEnum.VISUALFORCE.name
 
     def run(self):
-        sf_html = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.VISUALFORCE.url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
-        page_soup = BeautifulSoup(sf_html, "html.parser")
-        reference_soup = page_soup.find_all(text="Standard Component Reference",class_="toc-text")[0].parent.parent.parent
-        span_list = reference_soup.find_all("span", class_="toc-text")
-        for span in span_list:
-            link = span.parent
-            with self.cache_lock:
-                self.cache.append(
+        try:
+            # TODO: basically a replica of Apex, but with diff DocTypeEnum and "id" being searched for. Could use DRYing
+            sf_document = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.VISUALFORCE.toc_url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
+            sf_json = json.loads(sf_document)
+            sf_toc = sf_json["toc"]
+            reference_toc = filter(lambda x: "id" in x and x["id"] == "pages_compref", sf_toc)
+            for toc_entry in getAllTocLeaves(next(reference_toc)):
+                with self.cache_lock:
+                    self.cache.append(
                         SalesforceReferenceCacheEntry(
-                            span.string,
-                            link["href"],
+                            toc_entry["text"],
+                            toc_entry["a_attr"]["href"],
                             DocTypeEnum.VISUALFORCE.name
                         )
                     )
+        except Exception as e:
+            self.logRetrievalException();
+
         self.done_callback()
 
-class ServiceConsoleDocScrapingStrategy(DocRetrievalStrategy):
+class ServiceConsoleDocJsonTocBasedStrategy(DocRetrievalStrategy):
     def __init__(self, window, cache, cache_lock, done_callback):
         DocRetrievalStrategy.__init__(self, window, cache, cache_lock, done_callback)
 
@@ -119,34 +135,57 @@ class ServiceConsoleDocScrapingStrategy(DocRetrievalStrategy):
         return DocTypeEnum.SERVICECONSOLE.name
 
     def run(self):
-        sf_html = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.SERVICECONSOLE.url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
-        page_soup = BeautifulSoup(sf_html, "html.parser")
-        reference_soup = page_soup.find_all("span", text=re.compile("Methods for \w"), class_="toc-text")
-        for reference in reference_soup:
-            span_list = reference.parent.parent.parent.find_all("span", class_="toc-text", text=re.compile("^(?!Methods for)"))
-            for span in span_list:
-                link = span.parent
-                with self.cache_lock:
-                    self.cache.append(
-                        SalesforceReferenceCacheEntry(
-                            span.string,
-                            link["href"],
-                            DocTypeEnum.SERVICECONSOLE.name
+        try:
+            # TODO: has similarities to Apex/VF, but with diff DocTypeEnum, "text" being searched for (whereas others search on "id"), and the fact there are multiple "root" nodes for the ToC (one for each "Methods for" section). Could use DRYing maybe? Possibly not
+            sf_document = urllib.request.urlopen(urllib.request.Request(DocTypeEnum.SERVICECONSOLE.toc_url,None,{"User-Agent": "Mozilla/5.0"})).read().decode("utf-8")
+            sf_json = json.loads(sf_document)
+            sf_toc = sf_json["toc"]
+            for methods_toc in filter(lambda x: "id" in x and x["text"].startswith("Methods for"), sf_toc):
+                for toc_entry in getAllTocLeaves(methods_toc):
+                    with self.cache_lock:
+                        self.cache.append(
+                            SalesforceReferenceCacheEntry(
+                                toc_entry["text"],
+                                toc_entry["a_attr"]["href"],
+                                DocTypeEnum.SERVICECONSOLE.name
+                            )
                         )
-                    )
+        except Exception as e:
+            self.logRetrievalException();
+
         self.done_callback()
 
+def getAllTocLeafParents(toc,parent):
+    try:
+        for child in toc["children"]:
+            for leaf_parent in getAllTocLeafParents(child,toc):
+                yield leaf_parent
+    except KeyError:
+        yield parent
+
+def getAllTocLeaves(toc):
+    try:
+        for child in toc["children"]:
+            for leaf in getAllTocLeaves(child):
+                yield leaf
+    except KeyError:
+        yield toc
+
 class DocType:
-    def __init__(self, name, url, preferred_strategy):
+    def __init__(self, name, doc_base_url, toc_url, preferred_strategy):
         self.__name = name
-        self.__url = url
+        self.__doc_base_url = doc_base_url
+        self.__toc_url = toc_url
         self.__preferred_strategy = preferred_strategy
     @property
     def name(self):
         return self.__name
     @property
-    def url(self):
-        return self.__url
+    def doc_base_url(self):
+        return self.__doc_base_url
+    @property
+    def toc_url(self):
+        return self.__toc_url
     @property
     def preferred_strategy(self):
         return self.__preferred_strategy
@@ -154,18 +193,21 @@ class DocType:
 class DocTypeEnum:
     VISUALFORCE = DocType(
             "VISUALFORCE",
-            "http://developer.salesforce.com/docs/atlas.en-us.pages.meta/pages/",
-            VisualforceDocScrapingStrategy
+            "https://developer.salesforce.com/docs/atlas.en-us.pages.meta/pages/",
+            "https://developer.salesforce.com/docs/get_document/atlas.en-us.pages.meta",
+            VisualforceDocJsonTocBasedStrategy
         )
     APEX = DocType(
             "APEX",
-            "http://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/",
-            ApexDocScrapingStrategy
+            "https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/",
+            "https://developer.salesforce.com/docs/get_document/atlas.en-us.apexcode.meta",
+            ApexDocJsonTocBasedStrategy
         )
     SERVICECONSOLE = DocType(
             "SERVICECONSOLE",
-            "http://developer.salesforce.com/docs/atlas.en-us.api_console.meta/api_console/",
-            ServiceConsoleDocScrapingStrategy
+            "https://developer.salesforce.com/docs/atlas.en-us.api_console.meta/api_console/",
+            "https://developer.salesforce.com/docs/get_document/atlas.en-us.api_console.meta",
+            ServiceConsoleDocJsonTocBasedStrategy
         )
     @staticmethod
     def get_all():


### PR DESCRIPTION
There's been another update to the SF doc portal - it appears the doc
portal's front-end code has been revamped pretty thoroughly in
everything but visual appearance of the page, being replaced with an
angular app.

This has broken the scraping method, as the contents of the page are
now loaded in using Javascript. Scraping could in theory be made to
work again, but it would require a headless browser to render the page
which would be a real challenge from inside Sublime.

After a bit of digging in the (minified!) source for the SF Doc angular
app, I turned up some code that would populate the in-page Table of
Contents (ToC) from a URL structure that turned out to serve up a JSON
ToC, depending on what "document type" you plugged in. I've used this
to create new documentation retrieval strategies