### PR TITLE
Default browser setting

### DIFF
--- a/SalesforceReference.py
+++ b/SalesforceReference.py
@@ -167,4 +167,22 @@ class RetrieveIndexThread(threading.Thread):
                     url = self.doc_type.doc_base_url + entry.url
 
             if url:
-                webbrowser.open_new_tab(url)
+                open_new_tab = self.get_browser_open()
+                open_new_tab(url)
+
+    def get_browser_open(self):
+        defaults = sublime.load_settings('Default.sublime-settings')
+        settings = sublime.load_settings('SublimeSalesforceReference.sublime-settings')
+        platform = sublime.platform()
+        default_browser = settings.get('default_browser', defaults.get('default_browser'))
+        if default_browser:
+            if platform == 'osx':
+                browser_path = 'open -a ' + "\"%s\"" % default_browser
+            else:
+                browser_path = "\"%s\"" % default_browser
+            browser_path += ' %s'
+            open_new_tab = webbrowser.get(browser_path).open_new_tab
+        else:
+            open_new_tab = webbrowser.open_new_tab
+
+        return open_new_tab

--- a/SublimeSalesforceReference.sublime-settings
+++ b/SublimeSalesforceReference.sublime-settings
@@ -47,5 +47,6 @@
         "refreshCacheOnLoad": false,
         "excludeFromAllDocumentationCommand": false
       }
-    }
+    },
+    "default_browser": ""
 }


### PR DESCRIPTION
The plugin opens reference in default system browser (Safari for me). I don't want to use it, I want to use Chrome instead. So I made a `default_browser` setting, where you should specify a path to your browser executable, e.g.:
```json
{
	"default_browser": "/Applications/Google Chrome.app"
}
```
If the setting is empty it will still use the default browser.
I did this stuff for myself, but then realized I may be not the only one. Instead of posting an issue, I figured I might as well post a pull request. 